### PR TITLE
Changes to getopt and added option to prompt for password

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Acknowledgements: libfvde
 
 Copyright (C) 2011-2017, Omar Choudary <choudary.omar@gmail.com>
-                         Joachim Metz <joachim.metz@gmail.com>
+                         Joachim Metz <joachim.metz@gmail.com>,
+                         Rob Wu <rob@robwu.nl>
 

--- a/common/memory.h
+++ b/common/memory.h
@@ -88,6 +88,8 @@ extern "C" {
 
 #elif defined( WINAPI )
 #define memory_free( buffer ) \
+	( buffer == NULL ) ? \
+	TRUE : \
 	HeapFree( GetProcessHeap(), 0, (LPVOID) buffer )
 
 #elif defined( HAVE_FREE )

--- a/fvdetools/Makefile.am
+++ b/fvdetools/Makefile.am
@@ -27,6 +27,7 @@ bin_PROGRAMS = \
 
 fvdeinfo_SOURCES = \
 	fvdeinfo.c \
+	fvdetools_askpassword.c fvdetools_askpassword.h \
 	fvdetools_getopt.c fvdetools_getopt.h \
 	fvdetools_i18n.h \
 	fvdetools_libbfio.h \
@@ -58,6 +59,7 @@ fvdeinfo_LDADD = \
 
 fvdemount_SOURCES = \
 	fvdemount.c \
+	fvdetools_askpassword.c fvdetools_askpassword.h \
 	fvdetools_getopt.c fvdetools_getopt.h \
 	fvdetools_i18n.h \
 	fvdetools_libbfio.h \

--- a/fvdetools/fvdetools_askpassword.c
+++ b/fvdetools/fvdetools_askpassword.c
@@ -1,0 +1,215 @@
+/*
+ * Function to read password from stdin
+ *
+ * Copyright (C) 2017, Rob Wu <rob@robwu.nl>
+ *
+ * Refer to AUTHORS for acknowledgements.
+ *
+ * This software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <common.h>
+#include <memory.h>
+#include <stdio.h>
+#include <types.h>
+
+#if defined( _WIN32 )
+#include <conio.h>
+#else
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+#include "fvdetools_askpassword.h"
+
+#if defined( _WIN32 ) && defined( HAVE_WIDE_SYSTEM_CHARACTER )
+#undef getch // conio.h defines getch as _getch, replace with _getwch
+#define getch _getwch
+#endif
+
+#if !defined( _WIN32 )
+// The code in fvdetools_askpassword ensures that getchar behaves like _getch.
+#if defined( HAVE_WIDE_SYSTEM_CHARACTER )
+#define getch getwchar
+#else
+#define getch getchar
+#endif
+#endif
+
+system_character_t *reallocate_password_buffer(
+                     system_character_t * password_buffer,
+                     size_t size ) {
+	system_character_t *newbuffer = memory_reallocate(
+	                                 password_buffer,
+	                                 size * sizeof( system_character_t ) );
+	if( newbuffer == NULL )
+	{
+		fvdetools_free_password(
+		 password_buffer );
+	}
+
+	return newbuffer;
+}
+
+// returns 1 on success, 0 on failure.
+// asked_password becomes a non-NULL pointer (and the return value is 1)
+// iff the call succeeded.
+int fvdetools_ask_password(
+     system_character_t ** asked_password,
+     const system_character_t * prompt )
+{
+	size_t asked_password_length = 0;
+	size_t input_buffer_size = 0;
+	system_character_t ch;
+	system_character_t *password_buffer = NULL;
+	int changedmode = 0;
+	char *error = NULL;
+
+	// First try to force the terminal to not echo the password to stdout.
+
+	// Note: errors in attempts to change the terminal mode are deliberately
+	// ignored, in case stdio is a pipe instead of a console.
+#if defined( _WIN32 )
+	HANDLE hStdin = GetStdHandle(
+	                 STD_INPUT_HANDLE );
+	DWORD oldmode, newmode;
+    if( GetConsoleMode(
+	     hStdin,
+	     &oldmode ) )
+	{
+		newmode = oldmode;
+		newmode &= ~ENABLE_ECHO_INPUT;
+		if( SetConsoleMode(
+		     hStdin,
+		     newmode ) )
+		{
+			changedmode = 1;
+		}
+	}
+#else
+	struct termios old_termios, new_termios;
+	if( tcgetattr(
+	     STDIN_FILENO,
+	     &old_termios ) == 0 )
+	{
+		new_termios = old_termios;
+		new_termios.c_lflag &= ~(ECHO | ICANON);
+		if( tcsetattr(
+		     STDIN_FILENO,
+		     TCSADRAIN,
+		     &new_termios ) == 0 )
+		{
+			changedmode = 1;
+		}
+	}
+#endif
+
+	// After disabling echoing of input, prompt for the password.
+	printf(
+	 "%s ",
+	 prompt );
+	fflush( stdout );
+
+	for( ;; )
+	{
+		ch = getch();
+		if( ( ch == (system_character_t) '\n' )
+		 || ( ch == (system_character_t) '\r' )
+#if defined( HAVE_WIDE_SYSTEM_CHARACTER )
+		 || ( ch == WEOF )
+#else
+		 || ( ch == EOF )
+#endif
+		 || ( ch == (system_character_t) '\0') )
+		{
+			break;
+		}
+
+		// Backspace and DEL.
+		if( (ch == (system_character_t) '\b' )
+		 || (ch == (system_character_t) 127 ) )
+		{
+			if( asked_password_length > 0 )
+			{
+				--asked_password_length;
+			}
+			continue;
+		}
+
+		if( input_buffer_size <= asked_password_length )
+		{
+			// Allocate more than necessary to avoid constant reallocation.
+			password_buffer = reallocate_password_buffer(
+			                   password_buffer,
+			                   asked_password_length * 2 + 1 );
+			if( password_buffer == NULL )
+			{
+				error = "Failed to allocate memory for password";
+				break;
+			}
+		}
+		password_buffer[ asked_password_length++ ] = ch;
+	}
+
+	password_buffer = reallocate_password_buffer(
+	                   password_buffer,
+	                   asked_password_length + 1 );
+	if( password_buffer == NULL )
+	{
+		error = "Failed to allocate memory for password terminator";
+	}
+	else
+	{
+		password_buffer[ asked_password_length ] = (system_character_t) '\0';
+	}
+
+	// Restore the console / terminal state.
+	if( changedmode )
+	{
+#if defined( _WIN32 )
+		SetConsoleMode(
+		 hStdin,
+		 oldmode );
+#else
+		tcsetattr(
+		 STDIN_FILENO,
+		 TCSADRAIN,
+		 &old_termios );
+#endif
+	}
+
+	printf( "\n" );
+
+	if( error )
+	{
+		fvdetools_free_password(
+		 password_buffer );
+		fprintf(
+		 stderr,
+		 "Failed to get password: %s\n",
+		 error );
+		*asked_password = NULL;
+		return 0;
+	}
+
+	*asked_password = password_buffer;
+	return 1;
+}
+
+void fvdetools_free_password(
+      system_character_t* asked_password )
+{
+	memory_free(
+	 asked_password );
+}

--- a/fvdetools/fvdetools_askpassword.h
+++ b/fvdetools/fvdetools_askpassword.h
@@ -1,0 +1,43 @@
+/*
+ * Function to read password from stdin
+ *
+ * Copyright (C) 2017, Rob Wu <rob@robwu.nl>
+ *
+ * Refer to AUTHORS for acknowledgements.
+ *
+ * This software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined( _FVDETOOLS_ASKPASSWORD_H )
+#define _FVDETOOLS_ASKPASSWORD_H
+
+#include <common.h>
+#include <types.h>
+
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
+int fvdetools_ask_password(
+     system_character_t ** asked_password,
+     const system_character_t * prompt );
+
+void fvdetools_free_password(
+      system_character_t* asked_password );
+
+#if defined( __cplusplus )
+}
+#endif
+
+#endif /* !defined( _FVDETOOLS_ASKPASSWORD_H ) */

--- a/fvdetools/fvdetools_getopt.c
+++ b/fvdetools/fvdetools_getopt.c
@@ -48,6 +48,10 @@ system_character_t *optarg = NULL;
  */
 system_integer_t optopt = 0;
 
+/* The current argument value, if it has multiple parameterless options.
+ */
+system_character_t *pending_argument = NULL;
+
 /* Get the program options
  * Function for platforms that do not have the getopt function
  * Returns the option character processed, or -1 on error,
@@ -63,25 +67,33 @@ system_integer_t fvdetools_getopt(
 	static char *function              = "fvdetools_getopt";
 	size_t options_string_length       = 0;
 
-	if( optind >= argument_count )
+	if( pending_argument != NULL )
+	{
+		argument_value = pending_argument;
+		pending_argument = NULL;
+	}
+	else if( optind >= argument_count )
 	{
 		return( (system_integer_t) -1 );
 	}
-	argument_value = argument_values[ optind ];
+	else
+	{
+		argument_value = argument_values[ optind ];
 
-	/* Check if the argument value is not an empty string
-	 */
-	if( *argument_value == 0 )
-	{
-		return( (system_integer_t) -1 );
+		/* Check if the argument value is not an empty string
+		 */
+		if( *argument_value == 0 )
+		{
+			return( (system_integer_t) -1 );
+		}
+		/* Check if the first character is a option marker '-'
+		 */
+		if( *argument_value != (system_character_t) '-' )
+		{
+			return( (system_integer_t) -1 );
+		}
+		argument_value++;
 	}
-	/* Check if the first character is a option marker '-'
-	 */
-	if( *argument_value != (system_character_t) '-' )
-	{
-		return( (system_integer_t) -1 );
-	}
-	argument_value++;
 
 	/* Check if long options are provided '--'
 	 */
@@ -133,6 +145,10 @@ system_integer_t fvdetools_getopt(
 		if( *argument_value == (system_character_t) '\0' )
 		{
 			optind++;
+		}
+		else
+		{
+			pending_argument = argument_value;
 		}
 	}
 	/* Check if the argument is right after the option flag with no space in between

--- a/manuals/fvdeinfo.1
+++ b/manuals/fvdeinfo.1
@@ -8,8 +8,8 @@
 .Nm fvdeinfo
 .Op Fl e Ar filename
 .Op Fl o Ar offset
-.Op Fl p Ar password
-.Op Fl r Ar password
+.Op Fl p Ar password | Fl P
+.Op Fl r Ar password | Fl R
 .Op Fl hvV
 .Va Ar source
 .Sh DESCRIPTION
@@ -36,8 +36,12 @@ shows this help
 specify the volume offset
 .It Fl p Ar password
 specify the password
+.It Fl P
+prompt for the password
 .It Fl r Ar password
 specify the recovery password
+.It Fl R
+prompt for the recovery password
 .It Fl v
 verbose output to stderr
 .It Fl V

--- a/manuals/fvdeinfo.1
+++ b/manuals/fvdeinfo.1
@@ -34,7 +34,7 @@ specify the name of the EncryptedRoot.plist.wipekey file
 shows this help
 .It Fl o Ar offset
 specify the volume offset
-.It fl p Ar password
+.It Fl p Ar password
 specify the password
 .It Fl r Ar password
 specify the recovery password

--- a/manuals/fvdemount.1
+++ b/manuals/fvdemount.1
@@ -8,8 +8,8 @@
 .Nm fvdemount
 .Op Fl e Ar filename
 .Op Fl o Ar offset
-.Op Fl p Ar password
-.Op Fl r Ar password
+.Op Fl p Ar password | Fl P
+.Op Fl r Ar password | Fl R
 .Op Fl X Ar extended_options
 .Op Fl hvV
 .Va Ar source
@@ -37,8 +37,12 @@ shows this help
 specify the volume offset
 .It Fl p Ar password
 specify the password
+.It Fl P
+prompt for the password
 .It Fl r Ar password
 specify the recovery password
+.It Fl R
+prompt for the recovery password
 .It Fl v
 verbose output to stderr
 .It Fl V

--- a/tests/fvde_test_getopt.c
+++ b/tests/fvde_test_getopt.c
@@ -47,6 +47,10 @@ system_character_t *optarg = NULL;
  */
 system_integer_t optopt = 0;
 
+/* The current argument value, if it has multiple parameterless options.
+ */
+system_character_t *pending_argument = NULL;
+
 /* Get the program options
  * Function for platforms that do not have the getopt function
  * Returns the option character processed, or -1 on error,
@@ -62,25 +66,33 @@ system_integer_t fvde_test_getopt(
 	static char *function              = "fvde_test_getopt";
 	size_t options_string_length       = 0;
 
-	if( optind >= argument_count )
+	if( pending_argument != NULL )
+	{
+		argument_value = pending_argument;
+		pending_argument = NULL;
+	}
+	else if( optind >= argument_count )
 	{
 		return( (system_integer_t) -1 );
 	}
-	argument_value = argument_values[ optind ];
+	else
+	{
+		argument_value = argument_values[ optind ];
 
-	/* Check if the argument value is not an empty string
-	 */
-	if( *argument_value == 0 )
-	{
-		return( (system_integer_t) -1 );
+		/* Check if the argument value is not an empty string
+		 */
+		if( *argument_value == 0 )
+		{
+			return( (system_integer_t) -1 );
+		}
+		/* Check if the first character is a option marker '-'
+		 */
+		if( *argument_value != (system_character_t) '-' )
+		{
+			return( (system_integer_t) -1 );
+		}
+		argument_value++;
 	}
-	/* Check if the first character is a option marker '-'
-	 */
-	if( *argument_value != (system_character_t) '-' )
-	{
-		return( (system_integer_t) -1 );
-	}
-	argument_value++;
 
 	/* Check if long options are provided '--'
 	 */
@@ -132,6 +144,10 @@ system_integer_t fvde_test_getopt(
 		if( *argument_value == (system_character_t) '\0' )
 		{
 			optind++;
+		}
+		else
+		{
+			pending_argument = argument_value;
 		}
 	}
 	/* Check if the argument is right after the option flag with no space in between


### PR DESCRIPTION
I have added two new options, `-P` and `-R` to prompt for the password and recovery password, respectively. The ability to specify a password without explicitly passing it through the command-line arguments fixes #16 and [Debian bug 867110](https://bugs.debian.org/867110).

Before adding the feature, I fixed a few bugs, including major issues such undefined memory deallocation behavior on Windows and infinite loops in argument parsing.

I suggest to review each commit in isolation (and read their commit messages to understand the context of each commit).