### PR TITLE
Ignoring missed passphrase wrapped kek instead of returning error

### DIFF
--- a/libfvde/libfvde_encrypted_metadata.c
+++ b/libfvde/libfvde_encrypted_metadata.c
@@ -4760,15 +4760,8 @@ int libfvde_encrypted_metadata_get_volume_master_key(
 
 			if( result == -1 )
 			{
-				libcerror_error_set(
-				 error,
-				 LIBCERROR_ERROR_DOMAIN_IO,
-				 LIBCERROR_IO_ERROR_GENERIC,
-				 "%s: unable to retrieve passphrase wrapped KEK: %d from encryption context plist.",
-				 function,
-				 passphrase_wrapped_kek_index );
-
-				goto on_error;
+				++passphrase_wrapped_kek_index;
+				continue;
 			}
 			else if( result == 0 )
 			{


### PR DESCRIPTION
Hi @joachimmetz,

It looks that some "service" users from CryptoUsers don't have KeyWrappedKekStruct which doesn't seem to be an error. Here is decrypted wipeKey sample — [EncryptedRoot.plist.wipekey_decrypted.zip](https://github.com/libyal/libfvde/files/2911069/EncryptedRoot.plist.wipekey_decrypted.zip)

I wanted to add verbose output as well, but it seems like the whole partition is being dumped through stderr.